### PR TITLE
Update container names and switch to forward slashes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
-﻿services:
+﻿name: gml-core
+services:
   filebrowser:
     image: filebrowser/filebrowser
+    container_name: file-browser
     user: "${UID}:${GID}"
     environment:
       - FB_BASEURL=/filebrowser
@@ -16,7 +18,7 @@
 
   gml-web-api:
     image: gml-web-api-image
-    container_name: gml-web-api-container
+    container_name: gml-web-api
     build:
       dockerfile: src/Gml.WebApi/Dockerfile
     volumes:
@@ -28,7 +30,7 @@
 
   gml-web-admin:
     image: gml-web-admin-image
-    container_name: gml-web-admin-container
+    container_name: gml-web-admin
     build:
       context: .
       dockerfile: src/Gml.Web.Panel/Dockerfile

--- a/src/Gml.Web.Panel/Components/Pages/ProfilesList.razor.cs
+++ b/src/Gml.Web.Panel/Components/Pages/ProfilesList.razor.cs
@@ -117,8 +117,8 @@ namespace GmlAdminPanel.Components.Pages
                 Files = ProfileInfo.Files.Select(c => new System.IO.FileInfo(c.Directory)).ToList();
 
 
-                filesToView = Files.Select(c => c.FullName.Split($"{ProfileInfo.ProfileName}\\").LastOrDefault())
-                    .Select(c => c.Split('\\').First())
+                filesToView = Files.Select(c => c.FullName.Split($"{ProfileInfo.ProfileName}/").LastOrDefault())
+                    .Select(c => c.Split('/').First())
                     .Distinct()
                     .ToList();
 
@@ -230,14 +230,14 @@ namespace GmlAdminPanel.Components.Pages
 
             var path = args.Item.GetHierarchyPath(args.Item);
 
-            var directoryPath = $"{ProfileInfo.ProfileName}\\{path}\\";
+            var directoryPath = $"{ProfileInfo.ProfileName}/{path}/";
 
             var children = ProfileInfo.Files
                 .Where(c => c.Directory.Contains(directoryPath))
                 .ToList();
 
             var files = children
-                .Where(c => c.Directory.Split(directoryPath).Last().Count(c => c == '\\') == 0)
+                .Where(c => c.Directory.Split(directoryPath).Last().Count(c => c == '/') == 0)
                 .Select(c => new FileNode
                 {
                     Parent = args.Item,
@@ -249,7 +249,7 @@ namespace GmlAdminPanel.Components.Pages
 
             var directories = children.Except(files.Select(f => f.CurrentFile))
                 .Where(c => c.Directory.Contains(directoryPath))
-                .Select(c => c.Directory.Split(directoryPath).Last()).Select(c => c.Split('\\').First()).Distinct()
+                .Select(c => c.Directory.Split(directoryPath).Last()).Select(c => c.Split('/').First()).Distinct()
                 .ToList()
                 .Select(c => new FolderNode
                 {

--- a/src/Gml.Web.Panel/Models/Hierarchy/Files.cs
+++ b/src/Gml.Web.Panel/Models/Hierarchy/Files.cs
@@ -28,6 +28,6 @@ public class Node
         if (node.Parent == null)
             return node.Directory;
 
-        return string.Concat(GetHierarchyPath(node.Parent), "\\", node.Directory);
+        return string.Concat(GetHierarchyPath(node.Parent), "/", node.Directory);
     }
 }

--- a/src/Gml.Web.Panel/Program.cs
+++ b/src/Gml.Web.Panel/Program.cs
@@ -16,7 +16,7 @@ builder.Services.AddSession(options =>
     options.Cookie.HttpOnly = true;
     options.Cookie.IsEssential = true;
 });
-builder.Services.AddHttpClient("GmlApi", client => client.BaseAddress = new Uri("https://localhost:5000"));
+builder.Services.AddHttpClient("GmlApi", client => client.BaseAddress = new Uri("http://gml-web-api:8080"));
 builder.Services.AddScoped<GmlAdminPanel.GmlApiService>();
 var app = builder.Build();
 // Configure the HTTP request pipeline.


### PR DESCRIPTION
The docker-compose file has been updated with simplified container names. The complex '.container' endings have been removed for brevity and tidiness. Additionally, all instances of backslashes used in paths have been replaced with forward slashes to improve compatibility across multiple platforms. Lastly, the `GmlApi` client's BaseAddress has been updated.