### PR TITLE
Remove unnecessary volume mounts in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
       - FB_BASEURL=/filebrowser
     volumes:
       - shared-volume:/srv
-      - /DATA_DIR:/data
-      - /CONFIG_DIR:/config
     restart: always
     ports:
       - 5005:80
@@ -42,9 +40,6 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://+:8081;http://+:8082;
-    volumes:
-      - ${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro
-      - ${APPDATA}/ASP.NET/Https:/root/.aspnet/https:ro
 
 networks:
   gml-network:


### PR DESCRIPTION
The commit removes certain volume mounts from the docker-compose.yml file. Specifically, /DATA_DIR:/data, /CONFIG_DIR:/config, and ASPNETCORE paths have been eliminated. These changes aim to streamline the configuration and ensure a cleaner setup.